### PR TITLE
Adiciona dependências do compose 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,12 @@ android {
         testInstrumentationRunner = AppConfig.androidTestInstrumentation
     }
 
+    buildFeatures {
+        viewBinding = true
+        dataBinding = true
+        compose = true
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -30,12 +36,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    viewBinding {
-        android.buildFeatures.viewBinding = true
-    }
-
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = Versions.compose_version
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,6 @@ android {
     buildFeatures {
         viewBinding = true
         dataBinding = true
-        compose = true
     }
 
     buildTypes {
@@ -38,10 +37,6 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = Versions.compose_version
     }
 }
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -85,5 +85,5 @@ fun DependencyHandler.testImplementation(list: List<String>) {
 }
 
 fun DependencyHandlerScope.composeUi() {
-	api(Libs.compose)
+	implementation(Libs.compose)
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -1,21 +1,28 @@
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.kotlin.dsl.DependencyHandlerScope
 
 object Libs {
 	//std
 	private const val kotlinStdLib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin_version}"
-	private val core_ktx = "androidx.core:core-ktx:${Versions.core_ktx_version}"
+	private const val core_ktx = "androidx.core:core-ktx:${Versions.core_ktx_version}"
 	const val gradle = "com.android.tools.build:gradle:${Versions.gradle_version}"
 	const val kotlin_gradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin_version}"
 
 	//android ui
-	private val appcompat = "androidx.appcompat:appcompat:${Versions.appcompat_version}"
-	private val material = "com.google.android.material:material:${Versions.material_version}"
-	private val constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.constraintlayout_version}"
+	private const val appcompat = "androidx.appcompat:appcompat:${Versions.appcompat_version}"
+	private const val material = "com.google.android.material:material:${Versions.material_version}"
+	private const val constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.constraintlayout_version}"
+
+	//	compose
+	private const val composeUi ="androidx.compose.ui:ui:${Versions.compose_version}"
+	private const val composeUiTooling ="androidx.compose.ui:ui-tooling:${Versions.compose_version}"
+	private const val composeMaterial ="androidx.compose.material:material:${Versions.compose_version}"
+	private const val composeActivity ="androidx.activity:activity-compose:${Versions.compose_activity_version}"
 
 	//tests
-	private val junit = "junit:junit:${Versions.junit_version}"
-	private val ext_junit = "androidx.test.ext:junit:${Versions.ext_junit_version}"
-	private val espresso_core = "androidx.test.espresso:espresso-core:${Versions.espresso_core_version}"
+	private const val junit = "junit:junit:${Versions.junit_version}"
+	private const val ext_junit = "androidx.test.ext:junit:${Versions.ext_junit_version}"
+	private const val espresso_core = "androidx.test.espresso:espresso-core:${Versions.espresso_core_version}"
 
 	val coreModuleLibraries = listOf(
 		kotlinStdLib,
@@ -36,6 +43,13 @@ object Libs {
 
 	val testLibraries = listOf(
 		junit,
+	)
+
+	val compose = listOf(
+		composeUi,
+		composeUiTooling,
+		composeMaterial,
+		composeActivity
 	)
 }
 
@@ -68,4 +82,8 @@ fun DependencyHandler.testImplementation(list: List<String>) {
 	list.forEach { dependency ->
 		add("testImplementation", dependency)
 	}
+}
+
+fun DependencyHandlerScope.composeUi() {
+	api(Libs.compose)
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
 
 	//app
-	const val gradle_version = "7.1.1"
+	const val gradle_version = "7.1.2"
 	const val kotlin_version = "1.6.10"
 
 
@@ -10,6 +10,8 @@ object Versions {
 	const val appcompat_version = "1.4.1"
 	const val material_version = "1.5.0"
 	const val constraintlayout_version = "2.1.3"
+	const val compose_version = "1.1.1"
+	const val compose_activity_version = "1.4.0"
 
 	//tests
 	const val junit_version = "4.13.2"

--- a/coreUi/build.gradle.kts
+++ b/coreUi/build.gradle.kts
@@ -13,9 +13,20 @@ android {
 		testInstrumentationRunner = AppConfig.androidTestInstrumentation
 	}
 
+	buildFeatures {
+		viewBinding = true
+		dataBinding = true
+		compose = true
+	}
+
 	kotlinOptions {
 		jvmTarget = AndroidConfig.jvmTarget
 	}
+
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = Versions.compose_version
+    }
 
 	compileOptions {
 		sourceCompatibility = AndroidConfig.sourceCompatibility
@@ -31,4 +42,6 @@ dependencies {
 
 	testImplementation(Libs.testLibraries)
 	androidTestImplementation(Libs.androidTestLibraries)
+
+	composeUi()
 }


### PR DESCRIPTION
Adiciona dependências do compose no core ui

Para utilizar compose em seu módulo use:
* composeUi() nas dependencias 
* buildFeatures.compose = true
* composeOptions {
              kotlinCompilerExtensionVersion = Versions.compose_version
    }